### PR TITLE
Removed domain field from ASNRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Example
 >>> asnwhois.query = ["212.58.246.94", "94.229.76.35"]
 >>> asnwhois.peers = True
 >>> asnwhois.result["212.58.246.94"]
-ASNRecord(asn='2818', prefix='212.58.224.0/19', asname='BBC', cn='GB', domain='BBC.CO.UK', isp='BBC', peers=['3356', '7473', '9031', '31133', '37105', '51088'])
+ASNRecord(asn='2818', prefix='212.58.224.0/19', asname='BBC', cn='GB', isp='BBC Internet Services, UK, GB', peers=['286', '3356'])
 >>> for q, r in asnwhois.result.items():
-...    print q, r.cn, r.domain
+...    print q, r.cn, r.isp
 ...
-94.229.76.35 GB UKSERVERS.COM
-212.58.246.94 GB BBC.CO.UK
+94.229.76.35 GB AS UK Dedicated Servers, Hosting and Co-Location, GB
+212.58.246.94 GB BBC Internet Services, UK, GB
 >>>
 ```

--- a/RashlyOutlaid/libwhois.py
+++ b/RashlyOutlaid/libwhois.py
@@ -24,7 +24,7 @@ furnished to do so, subject to the following conditions:
 import socket
 from collections import namedtuple
 
-ASNRecord = namedtuple("ASNRecord", ["asn", "prefix", "asname", "cn", "domain", "isp", "peers"])
+ASNRecord = namedtuple("ASNRecord", ["asn", "prefix", "asname", "cn", "isp", "peers"])
 
 class Whois(object):
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setup(
     name = "RashlyOutlaid",
-    version = "0.9.0",
+    version = "0.10.0",
     author = "Geir Skjotskift",
     author_email = "geir@underworld.no",
     description = "Perform ASN Whois against shadowserver.org",


### PR DESCRIPTION
Hi,

Shadowserver's whois no longer provide the "domain" field in the result. Here's a patch to remove it from RashlyOutlaid.

Otherwise, it crashes with 

```
---> 87             self._result[query] = ASNRecord(*asdata)
[...]
TypeError: __new__() takes exactly 8 arguments (7 given)
```

Cheers! 🍻
M-E